### PR TITLE
Increase readability in adbfs.cpp

### DIFF
--- a/adbfs.cpp
+++ b/adbfs.cpp
@@ -88,6 +88,16 @@ map<string,fileCache> fileData;
 map<int,bool> filePendingWrite;
 map<string,bool> fileTruncated;
 
+/*
+ * temporary path for this program
+ */
+const string TMP_PATH = "/tmp/adbfs/";
+
+/**
+   Main struct for FUSE interface.
+ */
+static struct fuse_operations adbfs_oper;
+
 /**
    Return the result of executing the given command string, using
    exec_command, on the local host.
@@ -95,11 +105,12 @@ map<string,bool> fileTruncated;
    @param command the command to execute.
    @see exec_command.
  */
-queue<string> shell(const string command)
-{
+queue<string> shell(const string command) {
     string actual_command;
     actual_command.assign(command);
+    
     shell_escape_command(actual_command);
+    
     return exec_command(actual_command);
 }
 
@@ -114,11 +125,12 @@ queue<string> shell(const string command)
    @see exec_command.
    @todo perhaps avoid use of local shell to simplify escaping.
  */
-queue<string> adb_shell(const string command)
-{
+queue<string> adb_shell(const string command) {
     string actual_command;
     actual_command.assign(command);
+    
     adb_shell_escape_command(actual_command);
+    
     actual_command.insert(0, "adb shell busybox ");
     return exec_command(actual_command);
 }
@@ -131,11 +143,10 @@ queue<string> adb_shell(const string command)
    @see adb_shell_escape_command.
    @todo check/simplify escaping.
  */
-void shell_escape_command(string& cmd)
-{
-    string_replacer(cmd,"\\","\\\\");
-    string_replacer(cmd,"'","\\'");
-    string_replacer(cmd,"`","\\`");
+void shell_escape_command(string& cmd) {
+    string_replacer(cmd, "\\", "\\\\");
+    string_replacer(cmd, "'", "\\'");
+    string_replacer(cmd, "`", "\\`");
 }
 
 /**
@@ -146,27 +157,27 @@ void shell_escape_command(string& cmd)
    @see shell_escape_command.
    @todo check/simplify escaping.
  */
-void adb_shell_escape_command(string& cmd)
-{
-    string_replacer(cmd,"\\","\\\\");
-    string_replacer(cmd,"(","\\(");
-    string_replacer(cmd,")","\\)");
-    string_replacer(cmd,"'","\\'");
-    string_replacer(cmd,"`","\\`");
-    string_replacer(cmd,"|","\\|");
-    string_replacer(cmd,"&","\\&");
-    string_replacer(cmd,";","\\;");
-    string_replacer(cmd,"<","\\<");
-    string_replacer(cmd,">","\\>");
-    string_replacer(cmd,"*","\\*");
-    string_replacer(cmd,"#","\\#");
-    string_replacer(cmd,"%","\\%");
-    string_replacer(cmd,"=","\\=");
-    string_replacer(cmd,"~","\\~");
-    string_replacer(cmd,"/[0;0m","");
-    string_replacer(cmd,"/[1;32m","");
-    string_replacer(cmd,"/[1;34m","");
-    string_replacer(cmd,"/[1;36m","");
+void adb_shell_escape_command(string& cmd) {
+    string_replacer(cmd, "\\", "\\\\");
+    string_replacer(cmd, "(", "\\(");
+    string_replacer(cmd, ")", "\\)");
+    string_replacer(cmd, "'", "\\'");
+    string_replacer(cmd, "`", "\\`");
+    string_replacer(cmd, "|", "\\|");
+    string_replacer(cmd, "&", "\\&");
+    string_replacer(cmd, ";", "\\;");
+    string_replacer(cmd, "<", "\\<");
+    string_replacer(cmd, ">", "\\>");
+    string_replacer(cmd, "*", "\\*");
+    string_replacer(cmd, "#", "\\#");
+    string_replacer(cmd, "%", "\\%");
+    string_replacer(cmd, "=", "\\=");
+    string_replacer(cmd, "~", "\\~");
+    
+    string_replacer(cmd, "/[0;0m", "");
+    string_replacer(cmd, "/[1;32m", "");
+    string_replacer(cmd, "/[1;34m", "");
+    string_replacer(cmd, "/[1;36m", "");
 }
 
 /**
@@ -176,9 +187,8 @@ void adb_shell_escape_command(string& cmd)
    @see shell_escape_command.
    @todo check/simplify escaping.
  */
-void shell_escape_path(string &path)
-{
-  string_replacer(path, " ", "\\ ");
+void shell_escape_path(string &path) {
+    string_replacer(path, " ", "\\ ");
 }
 
 /**
@@ -186,65 +196,53 @@ void shell_escape_path(string &path)
    it with 0755 permissions flags.
    @todo Should probably use mkstemp or friends.
  */
-void clearTmpDir(){
-    shell("rm -rf /tmp/adbfs");
-    mkdir("/tmp/adbfs/",0755);
-}
-
-/**
-   Set a given string to an adb push or pull command with given paths.
-   
-   @param cmd string to which the adb command is written.
-   @param push true for a push command, false for pull.
-   @param local_path path on local host for push or pull command.
-   @param remote_path path on remote device for push or pull command.
-   @see adb_pull.
-   @see adb_push.
- */
-void adb_push_pull_cmd(string& cmd, const bool push, 
-		       const string local_path, const string remote_path)
-{
-    cmd.assign("adb ");
-    cmd.append((push ? "push '" : "pull '"));
-    cmd.append((push ? local_path : remote_path));
-    cmd.append("' '");
-    cmd.append((push ? remote_path : local_path));
-    cmd.append("'");
+void clearTmpDir() {
+    string cmd = "rm -rf ";
+    cmd.append(TMP_PATH)
+    shell(cmd);
+    mkdir(TMP_PATH, 0755);
 }
 
 /**
    Copy (using adb pull) a file from the Android device to the local
    host.
 
-   @param remote_source Android-side file path to copy.
-   @param local_destination local host-side destination path for copy.
+   @param source Android-side file path to copy.
+   @param destination local host-side destination path for copy.
    @return result of the "adb pull ..." executed using exec_command.
    @see adb_push.
-   @see adb_push_pull_cmd.
    @todo perhaps avoid or simplify shell-escaping.
    @bug problems with files with spaces in filenames (adb bug?)
  */
-queue<string> adb_pull(const string remote_source,
-		       const string local_destination)
-{
-    string cmd;
-    adb_push_pull_cmd(cmd, false, local_destination, remote_source);
+queue<string> adb_pull(const string source,
+                       const string destination) {
+    string cmd = "adb pull '";
+    
+    cmd.append(source)
+       .append("' '")
+       .append(destination)
+       .append("'");
+    
     return exec_command(cmd);
 }
 
 /**
    Copy (using adb push) a file from the local host to the Android
    device. Very similar to adb_pull.
-
+   @param source local host-side source path to copy
+   @param destination Android-side destination path for copy
    @see adb_pull.
-   @see adb_push_pull_cmd.
    @bug problems with files with spaces in filenames (adb bug?)
  */
-queue<string> adb_push(const string local_source,
-		       const string remote_destination)
-{
-    string cmd;
-    adb_push_pull_cmd(cmd, true, local_source, remote_destination);
+queue<string> adb_push(const string source,
+                       const string destination) {
+    string cmd = "adb push '";
+    
+    cmd.append(source)
+       .append("' '")
+       .append(destination)
+       .append("'");
+    
     return exec_command(cmd);
 }
 
@@ -252,36 +250,42 @@ queue<string> adb_push(const string local_source,
    adbFS implementation of FUSE interface function fuse_operations.getattr.
    @todo check shell escaping.
  */
-static int adb_getattr(const char *path, struct stat *stbuf)
-{
+static int adb_getattr(const char *path, struct stat *stbuf) {
     int res = 0;
-    memset(stbuf, 0, sizeof(struct stat));
     queue<string> output;
-    string path_string;
-    path_string.assign(path);
+    
+    memset(stbuf, 0, sizeof(struct stat));
 
     // TODO caching?
-    if (true || fileData.find(path_string) ==  fileData.end() 
-	|| fileData[path_string].timestamp + 30 > time(NULL)){
-        string command = "stat -t \"";
-        command.append(path_string);
-        command.append("\"");
-        cout << command<<"\n";
+    if (true || fileData.find(*path) ==  fileData.end() ||
+            fileData[*path].timestamp + 30 > time(NULL)) {
+        
+        string command("stat -t \"");
+        command.append(*path)
+               .append("\"");
+        
+        cout << command
+             << "\n";
+        
         output = adb_shell(command);
-        fileData[path_string].statOutput = output;
-        fileData[path_string].timestamp = time(NULL);
-    }else{
+        
+        fileData[*path].statOutput = output;
+        fileData[*path].timestamp  = time(NULL);
+    } else {
         output = fileData[path_string].statOutput;
-        cout << "from cache " << output.front() <<"\n";
+        cout << "from cache "
+             << output.front()
+             << "\n";
     }
-    if (output.empty())
-        return -EIO;
+    
+    if (output.empty()) return -EIO;
+    
     vector<string> output_chunk = make_array(output.front());
-    if (output_chunk.size() < 13){
-        return -ENOENT;
-    }
+    
+    if (output_chunk.size() < 13) return -ENOENT;
+    
     while (output_chunk.size() > 15){
-        output_chunk.erase( output_chunk.begin());
+        output_chunk.erase(output_chunk.begin());
     }
     /*
        stat -t Explained:
@@ -301,25 +305,25 @@ static int adb_getattr(const char *path, struct stat *stbuf)
        last change as seconds since the Unix Epoch (%Z)
        I/O block size (%o)
        */
-    //stbuf->st_dev = atoi(output_chunk[1].c_str());     /* ID of device containing file */
-    stbuf->st_ino = atoi(output_chunk[7].c_str());     /* inode number */
     unsigned int raw_mode;
-    xtoi(output_chunk[3].c_str(),&raw_mode);
-    stbuf->st_mode = raw_mode | 0700;    /* protection */
-    stbuf->st_nlink = 1;   /* number of hard links */
-    stbuf->st_uid = atoi(output_chunk[4].c_str());     /* user ID of owner */
-    stbuf->st_gid = atoi(output_chunk[5].c_str());     /* group ID of owner */
-
     unsigned int device_id;
-    xtoi(output_chunk[6].c_str(),&device_id);
-    stbuf->st_rdev = device_id;    // device ID (if special file)
-
-    stbuf->st_size = atoi(output_chunk[1].c_str());    /* total size, in bytes */
-    stbuf->st_blksize = atoi(output_chunk[14].c_str()); /* blocksize for filesystem I/O */
-    stbuf->st_blocks = atoi(output_chunk[2].c_str());  /* number of blocks allocated */
-    stbuf->st_atime = atol(output_chunk[11].c_str());   /* time of last access */
-    stbuf->st_mtime = atol(output_chunk[12].c_str());   /* time of last modification */
-    stbuf->st_ctime = atol(output_chunk[13].c_str());   /* time of last status change */
+    
+    xtoi(output_chunk[3].c_str(), &raw_mode);
+    xtoi(output_chunk[6].c_str(), &device_id);
+    
+    //stbuf->st_dev = atoi(output_chunk[1].c_str());     /* ID of device containing file */
+    stbuf->st_ino     = atoi(output_chunk[7].c_str());   /* inode number                 */
+    stbuf->st_mode    = raw_mode | 0700;                 /* protection                   */
+    stbuf->st_nlink   = 1;                               /* number of hard links         */
+    stbuf->st_uid     = atoi(output_chunk[4].c_str());   /* user ID of owner             */
+    stbuf->st_gid     = atoi(output_chunk[5].c_str());   /* group ID of owner            */
+    stbuf->st_rdev    = device_id;                       /* device ID (if special file)  */
+    stbuf->st_size    = atoi(output_chunk[1].c_str());   /* total size, in bytes         */
+    stbuf->st_blksize = atoi(output_chunk[14].c_str());  /* blocksize for filesystem I/O */
+    stbuf->st_blocks  = atoi(output_chunk[2].c_str());   /* number of blocks allocated   */
+    stbuf->st_atime   = atol(output_chunk[11].c_str());  /* time of last access          */
+    stbuf->st_mtime   = atol(output_chunk[12].c_str());  /* time of last modification    */
+    stbuf->st_ctime   = atol(output_chunk[13].c_str());  /* time of last status change   */
 
     return res;
 }
@@ -329,140 +333,160 @@ static int adb_getattr(const char *path, struct stat *stbuf)
    adbFS implementation of FUSE interface function fuse_operations.readdir.
    @todo check shell escaping.
  */
-static int adb_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
-    off_t offset, struct fuse_file_info *fi)
-{
+static int adb_readdir(const char *path,
+		               void *buf,
+		               fuse_fill_dir_t filler,
+		               off_t offset,
+		               struct fuse_file_info *fi) {
     (void) offset;
     (void) fi;
-    string path_string;
-    string local_path_string;
-    path_string.assign(path);
-    local_path_string.assign("/tmp/adbfs/");
-    string_replacer(path_string,"/","-");
-    local_path_string.append(path_string);
-    path_string.assign(path);
-
+    
+    string device_path(*path);
+    string local_path(TMP_PATH);
+    string command("ls -1a --color=none \"");
+    
     queue<string> output;
-    string command = "ls -1a --color=none \"";
-    command.append(path_string);
-    command.append("\"");
+    
+    string_replacer(device_path, "/", "-");
+    
+    local_path_string.append(device_path);
+    
+    command.append(*path)
+           .append("\"");
+    
     output = adb_shell(command);
-    if (output.empty())
-        return -EIO;
+    if (output.empty()) return -EIO;
+    
     vector<string> output_chunk = make_array(output.front());
-    if (output_chunk.size() >6){
-        return -ENOENT;
-    }
-    while (output.size() > 0){
+    if (output_chunk.size() > 6) return -ENOENT;
+    
+    while (output.size() > 0) {
         filler(buf, output.front().c_str(), NULL, 0);
         output.pop();
     }
-
-
+    
     return 0;
 }
 
 
-static int adb_open(const char *path, struct fuse_file_info *fi)
-{
-    string path_string;
-    string local_path_string;
-    path_string.assign(path);
-    local_path_string.assign("/tmp/adbfs/");
-    string_replacer(path_string,"/","-");
-    local_path_string.append(path_string);
-    path_string.assign(path);
-    cout << "-- " << path_string << " " << local_path_string << "\n";
-    if (!fileTruncated[path_string]){
-        queue<string> output;
-        string command = "stat -t \"";
-        command.append(path_string);
-        command.append("\"");
-        cout << command<<"\n";
-        output = adb_shell(command);
-        if (output.empty())
-            return -EIO;
-        vector<string> output_chunk = make_array(output.front());
-        if (output_chunk.size() < 13){
-            return -ENOENT;
-        }
-	path_string.assign(path);
-	local_path_string.assign("/tmp/adbfs/");
-	string_replacer(path_string,"/","-");
-	local_path_string.append(path_string);
-	shell_escape_path(local_path_string);
-	path_string.assign(path);
-        adb_pull(path_string,local_path_string);
-    }else{
-        fileTruncated[path_string] = false;
+static int adb_open(const char *path, struct fuse_file_info *fi) {
+    string local_path(TMP_PATH);
+    local_path.append(*path);
+    
+    cout << "-- "
+         << *path
+         << " "
+         << local_path
+         << "\n";
+    
+    if (fileTruncated[*path]) { // micro-optimization
+        fileTruncated[*path] = false;
+        
+        fi->fh = open(local_path.c_str(), fi->flags);
+        
+        return 0;
     }
+    
+    queue<string> output;
+    string command = "stat -t \"";
+    
+    command.append(*path);
+           .append("\"");
+    
+    cout << command
+         << "\n";
+    
+    output = adb_shell(command);
+    if (output.empty()) return -EIO;
+    
+    // mildly reduce memory footprint
+    if (make_array(output.front()).size() < 13) return -ENOENT;
+    
+    shell_escape_path(local_path);
+    
+    adb_pull(*path, local_path);
 
-    fi->fh = open(local_path_string.c_str(), fi->flags);
-
+    fi->fh = open(local_path.c_str(), fi->flags);
+    
     return 0;
 }
 
-static int adb_read(const char *path, char *buf, size_t size, off_t offset,
-    struct fuse_file_info *fi)
-{
-    int fd;
+static int adb_read(const char *path,
+                    char *buf,
+                    size_t size,
+                    off_t offset,
+                    struct fuse_file_info *fi) {
+    //string local_path_string = ""; // better for debugging
+    
+    int fd = fi->fh;
     int res;
-    fd = fi->fh; //open(local_path_string.c_str(), O_RDWR);
-    if(fd == -1)
-        return -errno;
+    //open(local_path_string.c_str(), O_RDWR);
+    
+    if (fd == -1) return -errno;
+    
     res = pread(fd, buf, size, offset);
     //close(fd);
-    if(res == -1)
-        res = -errno;
+    if (res == -1) res = -errno;
 
     return size;
 }
 
-static int adb_write(const char *path, const char *buf, size_t size, off_t offset, struct fuse_file_info *fi) {
-    string path_string;
-    string local_path_string;
-    path_string.assign(path);
-    //local_path_string.assign("/tmp/adbfs/");
-    //local_path_string.append(path_string);
-    shell_escape_path(local_path_string);
-
-    int fd = fi->fh; //open(local_path_string.c_str(), O_CREAT|O_RDWR|O_TRUNC);
-
+static int adb_write(const char *path,
+                     const char *buf,
+                     size_t size,
+                     off_t offset,
+                     struct fuse_file_info *fi) {
+    string device_path(*path);
+    string local_path = ""; // empty string is better than undefined
+    
+    //local_path.assign(TMP_PATH);
+    //local_path.append(device_path);
+    
+    shell_escape_path(local_path);
+    
+    int fd = fi->fh;
+    //open(local_path_string.c_str(), O_CREAT|O_RDWR|O_TRUNC);
+    
     filePendingWrite[fd] = true;
-
+    
     int res = pwrite(fd, buf, size, offset);
     //close(fd);
     //adb_push(local_path_string,path_string);
     //adb_shell("sync");
-    if (res == -1)
-        res = -errno;
+    
+    if (res == -1) res = -errno;
+    
     return res;
 }
 
 
 static int adb_flush(const char *path, struct fuse_file_info *fi) {
-    string path_string;
-    string local_path_string;
-    path_string.assign(path);
-    local_path_string.assign("/tmp/adbfs/");
-    string_replacer(path_string,"/","-");
-    local_path_string.append(path_string);
-    path_string.assign(path);
+    string local_path(TMP_PATH);
+    
+    local_path.append(*path);
+    
     int flags = fi->flags;
-    int fd = fi->fh;
-    cout << "flag is: "<< flags <<"\n";
-    if (filePendingWrite[fd]) {
-        filePendingWrite[fd] = false;
-        adb_push(local_path_string,path_string);
-        adb_shell("sync");
-    }
+    int fd    = fi->fh;
+    
+    cout << "flag is: "
+         << flags
+         << "\n";
+    
+    if (!filePendingWrite[fd]) return 0; // shortcut here
+    
+    filePendingWrite[fd] = false;
+    adb_push(local_path, *path);
+    adb_shell("sync");
+    
     return 0;
 }
 
 static int adb_release(const char *path, struct fuse_file_info *fi) {
     int fd = fi->fh;
+    
     filePendingWrite.erase(filePendingWrite.find(fd));
     close(fd);
+    
     return 0;
 }
 
@@ -472,186 +496,193 @@ static int adb_access(const char *path, int mask) {
 }
 
 static int adb_utimens(const char *path, const struct timespec ts[2]) {
-    string path_string;
-    string local_path_string;
-    path_string.assign(path);
-    fileData[path_string].timestamp = fileData[path_string].timestamp + 50;
-    local_path_string.assign("/tmp/adbfs/");
-    string_replacer(path_string,"/","-");
-    local_path_string.append(path_string);
-    path_string.assign(path);
+    string device_path(*path);
+    string local_path(TMP_PATH);
+    
+    fileData[device_path].timestamp = fileData[device_path].timestamp + 50;
+    
+    string_replacer(device_path,"/","-");
+    local_path.append(device_path);
 
     queue<string> output;
     string command = "touch \"";
-    command.append(path_string);
-    command.append("\"");
-    cout << command<<"\n";
+    
+    command.append(*path)
+           .append("\"");
+           
+    cout << command
+         << "\n";
+    
     adb_shell(command);
 
     return 0;
 }
 
 static int adb_truncate(const char *path, off_t size) {
-    string path_string;
-    string local_path_string;
-    path_string.assign(path);
-    fileData[path_string].timestamp = fileData[path_string].timestamp + 50;
-    local_path_string.assign("/tmp/adbfs/");
-    string_replacer(path_string,"/","-");
-    local_path_string.append(path_string);
-    path_string.assign(path);
+    string device_path(*path);
+    string local_path(TMP_PATH);
+    
+    fileData[device_path].timestamp = fileData[device_path].timestamp + 50;
+    
+    string_replacer(device_path, "/", "-");
+    local_path.append(device_path);
 
     queue<string> output;
     string command = "stat -t \"";
-    command.append(path_string);
-    command.append("\"");
-    cout << command<<"\n";
+    
+    command.append(*path)
+           .append("\"");
+    
+    cout << command
+         << "\n";
+         
     output = adb_shell(command);
-    if (output.empty())
-        return -EIO;
-    vector<string> output_chunk = make_array(output.front());
-    if (output_chunk.size() < 13){
-        adb_pull(path_string,local_path_string);
-    }
+    
+    if (output.empty()) return -EIO;
+    
+    // potentially lessen possibility for bugs by putting this in if condition
+    if (make_array(output.front()).size() < 13)
+        adb_pull(*path, local_path);
+    
+    fileTruncated[*path] = true;
+    
+    cout << "truncate[path="
+         << local_path
+         << "][size="
+         << size
+         << "]"
+         << endl;
 
-    fileTruncated[path_string] = true;
-
-    cout << "truncate[path=" << local_path_string << "][size=" << size << "]" << endl;
-
-    return truncate(local_path_string.c_str(),size);
+    return truncate(local_path.c_str(), size);
 }
 
 static int adb_mknod(const char *path, mode_t mode, dev_t rdev) {
-    string path_string;
-    string local_path_string;
-    path_string.assign(path);
-    local_path_string.assign("/tmp/adbfs/");
-    string_replacer(path_string,"/","-");
-    local_path_string.append(path_string);
-    path_string.assign(path);
-
-    cout << "mknod for " << local_path_string << "\n";
-    mknod(local_path_string.c_str(),mode, rdev);
-    adb_push(local_path_string,path_string);
+    string device_path(*path);
+    string local_path(TMP_PATH);
+    
+    string_replacer(device_path, "/", "-");
+    
+    local_path.append(device_path);
+    
+    cout << "mknod for "
+         << local_path
+         << "\n";
+    
+    mknod(local_path.c_str(), mode, rdev);
+    
+    adb_push(local_path, *path);
     adb_shell("sync");
-
-    fileData[path_string].timestamp = fileData[path_string].timestamp + 50;
-
+    
+    fileData[*path].timestamp = fileData[*path].timestamp + 50;
+    
     return 0;
 }
 
 static int adb_mkdir(const char *path, mode_t mode) {
-    string path_string;
-    string local_path_string;
-    path_string.assign(path);
-    fileData[path_string].timestamp = fileData[path_string].timestamp + 50;
-    local_path_string.assign("/tmp/adbfs/");
-    string_replacer(path_string,"/","-");
-    local_path_string.append(path_string);
-    path_string.assign(path);
-    string command;
-    command.assign("mkdir '");
-    command.append(path_string);
-    command.append("'");
+    string command("mkdir '");
+    
+    fileData[*path].timestamp = fileData[*path].timestamp + 50;
+    
+    command.append(*path)
+           .append("'");
+    
     adb_shell(command);
+    
     return 0;
 }
 
-static int adb_rename(const char *from, const char *to) {
-    string local_from_string,local_to_string ="/tmp/adbfs/";
-
-    local_from_string.append(from);
-    local_to_string.append(to);
+static int adb_rename(const char *source, const char *destination) {
     string command = "mv '";
-    command.append(from);
-    command.append("' '");
-    command.append(to);
-    command.append("'");
-    cout << "Renaming " << from << " to " << to <<"\n";
+    
+    command.append(*source)
+           .append("' '")
+           .append(TMP_PATH)
+           .append(*destination)
+           .append("'");
+    
+    cout << "Renaming "
+         << *source
+         << " to "
+         << *destination
+         << "\n";
+    
     adb_shell(command);
+    
     return 0;
 }
 
 static int adb_rmdir(const char *path) {
-    string path_string;
-    string local_path_string;
-    path_string.assign(path);
-    fileData[path_string].timestamp = fileData[path_string].timestamp + 50;
-    local_path_string.assign("/tmp/adbfs/");
-    string_replacer(path_string,"/","-");
-    local_path_string.append(path_string);
-    path_string.assign(path);
-
-    string command = "rmdir '";
-    command.append(path_string);
-    command.append("'");
+    //string local_path(TMP_PATH);
+    string command("rmdir '");
+    
+    fileData[*path].timestamp = fileData[*path].timestamp + 50;
+    
+    command.append(*path)
+           .append("'");
+    
     adb_shell(command);
 
-    //rmdir(local_path_string.c_str());
+    //rmdir(local_path.c_str());
     return 0;
 }
 
 static int adb_unlink(const char *path) {
-    string path_string;
-    string local_path_string;
-    path_string.assign(path);
-    fileData[path_string].timestamp = fileData[path_string].timestamp + 50;
-    local_path_string.assign("/tmp/adbfs/");
-    string_replacer(path_string,"/","-");
-    local_path_string.append(path_string);
-    path_string.assign(path);
-
-    string command = "rm '";
-    command.append(path_string);
-    command.append("'");
+    string device_path = *path;
+    string local_path  = TMP_PATH;
+    string command     = "rm '";
+    
+    fileData[*path].timestamp = fileData[*path].timestamp + 50;
+    
+    string_replacer(device_path,"/","-");
+    local_path.append(device_path);
+    
+    command.append(*path)
+           .append("'");
+    
     adb_shell(command);
 
-    unlink(local_path_string.c_str());
+    unlink(local_path.c_str());
+    
     return 0;
 }
 
-static int adb_readlink(const char *path, char *buf, size_t size)
-{
-    string path_string(path);
-    string_replacer(path_string, "'", "\\'");
-
-    string command = "readlink \"";
-    command.append(path_string);
-    command.append("\"");
-
-    queue<string> output;
-    output = adb_shell(command);
-
-    if(output.empty())
-       return -EINVAL;
-
+static int adb_readlink(const char *path, char *buf, size_t size) {
+    string device_path = *path;
+    string command     = "readlink \"";
+    
+    string_replacer(device_path, "'", "\\'");
+    
+    command.append(device_path)
+           .append("\"");
+    
+    queue<string> output = adb_shell(command);
+    
+    if (output.empty()) return -EINVAL;
+    
     string res = output.front();
+    
     if (res[0] == '/') {
         int pos = 0;
         int depth = -1;
+        
         while (path[pos] != '\0') {
             if (path[pos++] == '/') depth++;
         }
-
+        
         res.erase(0, 1);
-        while (depth > 0) {
+        
+        while (depth-- > 0) { // little more optimal
             res.insert(0, "../");
-            depth--;
         }
     }
-
+    
     size_t my_size = res.size();
-    if (my_size >= size)
-       return -ENOSYS;
+    if (my_size >= size) return -ENOSYS;
 
     memcpy(buf, res.c_str(), my_size + 1);
+    
     return 0;
 }
-
-/**
-   Main struct for FUSE interface.
- */
-static struct fuse_operations adbfs_oper;
 
 /**
    Set up the fuse_operations struct adbfs_oper using above adb_*
@@ -659,25 +690,27 @@ static struct fuse_operations adbfs_oper;
 
    @see fuse_main in fuse.h.
  */
-int main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
     clearTmpDir();
+    
     memset(&adbfs_oper, sizeof(adbfs_oper), 0);
-    adbfs_oper.readdir= adb_readdir;
-    adbfs_oper.getattr= adb_getattr;
-    adbfs_oper.access= adb_access;
-    adbfs_oper.open= adb_open;
-    adbfs_oper.flush = adb_flush;
-    adbfs_oper.release = adb_release;
-    adbfs_oper.read= adb_read;
-    adbfs_oper.write = adb_write;
-    adbfs_oper.utimens = adb_utimens;
+    
+    adbfs_oper.readdir  = adb_readdir;
+    adbfs_oper.getattr  = adb_getattr;
+    adbfs_oper.access   = adb_access;
+    adbfs_oper.open     = adb_open;
+    adbfs_oper.flush    = adb_flush;
+    adbfs_oper.release  = adb_release;
+    adbfs_oper.read     = adb_read;
+    adbfs_oper.write    = adb_write;
+    adbfs_oper.utimens  = adb_utimens;
     adbfs_oper.truncate = adb_truncate;
-    adbfs_oper.mknod = adb_mknod;
-    adbfs_oper.mkdir = adb_mkdir;
-    adbfs_oper.rename = adb_rename;
-    adbfs_oper.rmdir = adb_rmdir;
-    adbfs_oper.unlink = adb_unlink;
+    adbfs_oper.mknod    = adb_mknod;
+    adbfs_oper.mkdir    = adb_mkdir;
+    adbfs_oper.rename   = adb_rename;
+    adbfs_oper.rmdir    = adb_rmdir;
+    adbfs_oper.unlink   = adb_unlink;
     adbfs_oper.readlink = adb_readlink;
+    
     return fuse_main(argc, argv, &adbfs_oper, NULL);
 }


### PR DESCRIPTION
Bring consistency to improve readability, make several small optimizations in memory and method calls, remove redundant code, fix some small bugs. Also removed `adb_push_pull_cmd()` in favor of separating the two separate functionalities into their more logical (and already-existing) counterparts.
